### PR TITLE
chore: harden pytest collection to reduce CI regressions

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -22,6 +22,8 @@ norecursedirs =
     build
     *.egg-info
     sites
+    lib
+    tests_and_scripts
     appwrite-functions
     scripts
     integrations
@@ -66,6 +68,7 @@ collect_ignore =
     tests/test_streamlit_env.py
     tests/test_streamlit_pages.py
     tests/test_streamlit_secrets.py
+    src/diagnostic_api_test.py
 
 # Markers
 markers =
@@ -93,6 +96,10 @@ addopts =
     --ignore=tests/test_tiingo.py
     --ignore=tests/test_trade_api.js
     --ignore=tests/tiingo_integration.py
+    --ignore=tests/test_env_reload.py
+    --ignore=src/diagnostic_api_test.py
+    --ignore=lib
+    --ignore=tests_and_scripts
     # Only run properly mocked unit tests, not integration scripts
 
 [coverage:run]


### PR DESCRIPTION
## Summary\n- harden pytest collection rules to avoid non-unit/vendor test discovery\n- explicitly ignore known problematic paths during collection\n\n## Why\nThis reduces future CI instability from accidental collection of archived scripts, vendored libraries, and ad-hoc diagnostics.\n\n## Validation\n- ran .venv\\Scripts\\python.exe -m pytest --collect-only -q successfully\n